### PR TITLE
Add `con-nf` to the list of projects

### DIFF
--- a/projects/projects.yml
+++ b/projects/projects.yml
@@ -204,3 +204,11 @@ lean-acl-pairs:
     - adamtopaz
   report-build-failures: false
   
+con-nf:
+  description: |
+    A formalisation of the consistency of Quine's New Foundations axiom system, following [Randall Holmes' proof](https://randall-holmes.github.io/Nfproof/untangled.pdf). This is arguably the longest standing open question in set theory.
+  organization: 'leanprover-community'
+  maintainers:
+    - YaelDillies
+    - zeramorphic
+  report-build-failures: false


### PR DESCRIPTION
We've been working on our formalisation of the proof of the consistency of New Foundations set theory for a couple of months now, and I think it's mature enough to go on the projects page.